### PR TITLE
Deprecated bootdisk option changed to boot order

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -135,7 +135,7 @@ qm create $VMID -agent 1 -bios ovmf -name $VM_NAME -net0 virtio,bridge=vmbr0 \
   -onboot 1 -ostype l26 -scsihw virtio-scsi-pci
 pvesm alloc $STORAGE $VMID $DISK0 128 1>&/dev/null
 qm importdisk $VMID ${FILE%".gz"} $STORAGE ${IMPORT_OPT:-} 1>&/dev/null
-qm set $VMID -bootdisk sata0 -efidisk0 ${DISK0_REF},size=128K \
+qm set $VMID -boot order=sata0 -efidisk0 ${DISK0_REF},size=128K \
   -sata0 ${DISK1_REF},size=6G > /dev/null
 
 # Add serial port and enable console output

--- a/install.sh
+++ b/install.sh
@@ -136,7 +136,8 @@ qm create $VMID -agent 1 -bios ovmf -name $VM_NAME -net0 virtio,bridge=vmbr0 \
 pvesm alloc $STORAGE $VMID $DISK0 128 1>&/dev/null
 qm importdisk $VMID ${FILE%".gz"} $STORAGE ${IMPORT_OPT:-} 1>&/dev/null
 qm set $VMID -efidisk0 ${DISK0_REF},size=128K \
-  -sata0 ${DISK1_REF},size=6G -boot order=sata0 > /dev/null
+  -sata0 ${DISK1_REF},size=6G > /dev/null
+qm set $VMID -boot order=sata0 > /dev/null
 
 # Add serial port and enable console output
 set +o errtrace

--- a/install.sh
+++ b/install.sh
@@ -135,8 +135,8 @@ qm create $VMID -agent 1 -bios ovmf -name $VM_NAME -net0 virtio,bridge=vmbr0 \
   -onboot 1 -ostype l26 -scsihw virtio-scsi-pci
 pvesm alloc $STORAGE $VMID $DISK0 128 1>&/dev/null
 qm importdisk $VMID ${FILE%".gz"} $STORAGE ${IMPORT_OPT:-} 1>&/dev/null
-qm set $VMID -boot order=sata0 -efidisk0 ${DISK0_REF},size=128K \
-  -sata0 ${DISK1_REF},size=6G > /dev/null
+qm set $VMID -efidisk0 ${DISK0_REF},size=128K \
+  -sata0 ${DISK1_REF},size=6G -boot order=sata0 > /dev/null
 
 # Add serial port and enable console output
 set +o errtrace


### PR DESCRIPTION
bootdisk is deprecated cf. https://pve.proxmox.com/pve-docs/qm.1.html

Installation :

```
~# bash -c "$(wget -qLO - https://github.com/Najihel/proxmox_hassos_install/raw/master/install.sh)"
[INFO] Using 'local-lvm' for storage location.
[INFO] Container ID is 101.
Getting URL for latest Home Assistant disk image...
Downloading disk image...
Extracting disk image...
Creating VM...
Adding serial port and configuring console...
[INFO] Completed Successfully! New VM ID is 101.
```

Check Qemu config :

```
~# qm config 101
agent: 1
bios: ovmf
boot: order=sata0
efidisk0: local-lvm:vm-101-disk-0,size=4M
name: hassosova-4.19
net0: virtio=<removed>,bridge=vmbr0
onboot: 1
ostype: l26
sata0: local-lvm:vm-101-disk-1,size=6G
scsihw: virtio-scsi-pci
serial0: socket
smbios1: uuid=<removed>
vmgenid: <removed>
```