### PR TITLE
add support for .zip compressed images

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -113,6 +113,7 @@ msg "Extracting disk image..."
 case $FILE in
   *"gz") gunzip -f $FILE;;
   *"xz") xz -d $FILE;;
+  *"zip") unzip $FILE;;
   *) die "Unable to handle file extension '${FILE##*.}'.";;
 esac
 


### PR DESCRIPTION
Hi, 
thank you for this awesome script!
I ran into a minor issue though, in my case the script auto-downloads a Home Assistant OS image with a `.zip` file extension which is currently not handled by your script as far as I can see.
Therefore it exits with an error.

I added a one-liner to handle this case and now it works flawlessly.

If you believe this is some kind of user error on my side, I'd be glad if you let me know!

Best regards